### PR TITLE
Hotfix - High level wrapper for AES256 was broken. Added helper functions for generating keys and IVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,11 @@ A comprehensive toolkit providing essential utilities for development in Free Pa
 - 🔐 **Cryptography**
   - SHA3 implementation
   - SHA2 family (SHA-256, SHA-512, SHA-512/256)
-  - AES-256 encryption (CBC and CTR modes)
+  - AES-256 encryption
+    - CBC and CTR modes
+    - High-level interface with automatic Base64 encoding
+    - Low-level interface with raw binary operations
+    - Configurable padding modes (PKCS7 or None)
   - Secure hashing
   - Encryption utilities
   - Base64 encoding/decoding

--- a/docs/TidyKit.Crypto.md
+++ b/docs/TidyKit.Crypto.md
@@ -2,11 +2,19 @@
 
 ## Overview
 
-The TidyKit.Crypto module provides a comprehensive set of cryptographic operations, including modern encryption algorithms, secure hashing functions, and encoding utilities. All functionality is exposed through the `TCryptoKit` class, which provides static methods for ease of use.
+The TidyKit.Crypto module provides a high-level wrapper around various cryptographic operations, making them easy to use with string inputs and outputs. It handles:
+- String to bytes conversion
+- Base64 encoding of binary cryptographic outputs
+- Base64 decoding of encrypted data for decryption
+
+Base64 encoding is used because encrypted binary data cannot be safely stored in strings (they may contain null bytes or non-printable characters). This ensures encrypted data can be safely stored and transmitted as text.
+
+For low-level binary operations and NIST compliance testing, use the underlying implementation units directly (e.g., TidyKit.Crypto.AES256).
 
 ## Features
 
 - 🔑 **AES-256 Encryption**
+  - High-level string operations with automatic Base64 encoding
   - CBC mode with PKCS7 padding
   - CTR mode for streaming
   - NIST SP 800-38A compliant
@@ -41,13 +49,37 @@ begin
   FillChar(Key, SizeOf(Key), 0);
   FillChar(IV, SizeOf(IV), 0);
   
-  // CBC Mode
+  // CBC Mode - High-level string operations with automatic Base64 encoding
   CipherText := TCryptoKit.AES256EncryptCBC('secret text', Key, IV);
   PlainText := TCryptoKit.AES256DecryptCBC(CipherText, Key, IV);
   
-  // CTR Mode
+  // CTR Mode - High-level string operations with automatic Base64 encoding
   CipherText := TCryptoKit.AES256EncryptCTR('secret text', Key, IV);
   PlainText := TCryptoKit.AES256DecryptCTR(CipherText, Key, IV);
+end;
+```
+
+### Low-Level Binary Operations
+
+For NIST compliance testing or when working directly with binary data, use the TAES256 class:
+
+```pascal
+var
+  Key: TAESKey;
+  IV: TAESBlock;
+  PlainBytes, CipherBytes: TBytes;
+begin
+  // Initialize Key and IV (use secure random generation in practice)
+  FillChar(Key, SizeOf(Key), 0);
+  FillChar(IV, SizeOf(IV), 0);
+  
+  // CBC Mode - Raw binary operations
+  CipherBytes := TAES256.EncryptCBC(PlainBytes, Key, IV);
+  PlainBytes := TAES256.DecryptCBC(CipherBytes, Key, IV);
+  
+  // CTR Mode - Raw binary operations
+  CipherBytes := TAES256.EncryptCTR(PlainBytes, Key, IV);
+  PlainBytes := TAES256.DecryptCTR(CipherBytes, Key, IV);
 end;
 ```
 
@@ -244,3 +276,23 @@ We welcome contributions to improve the crypto module. Please ensure:
 ## License
 
 This module is part of TidyKit and is licensed under the same terms as the main project. 
+
+## Architecture
+
+### High-Level vs Low-Level APIs
+
+1. **TCryptoKit (High-Level)**
+   - String-based operations
+   - Automatic Base64 encoding/decoding
+   - Easy to use for common scenarios
+   - Handles binary-to-text conversion
+
+2. **TAES256 (Low-Level)**
+   - Raw binary operations
+   - NIST test vectors compliance
+   - Direct byte array manipulation
+   - No automatic encoding
+
+Choose the appropriate API based on your needs:
+- Use TCryptoKit for general application development
+- Use TAES256 for cryptographic protocol implementation or testing 

--- a/src/TidyKit.Crypto.AES256.pas
+++ b/src/TidyKit.Crypto.AES256.pas
@@ -1,8 +1,17 @@
 {*******************************************************************************
-  TidyKit.Crypto.AES256 - Advanced Encryption Standard (AES-256) Implementation
+  TidyKit.Crypto.AES256 - Low-Level AES-256 Implementation
   
   This unit provides a FIPS-compliant implementation of AES-256 encryption and
-  decryption in CBC and CTR modes. The implementation follows NIST standards:
+  decryption in CBC and CTR modes. It operates directly on raw binary data (bytes)
+  and is designed for:
+  1. NIST compliance and testing
+  2. Low-level cryptographic operations
+  3. Integration with other cryptographic protocols
+  
+  For string-based operations with automatic Base64 encoding, use the high-level
+  wrapper in TidyKit.Crypto unit instead.
+  
+  This implementation follows NIST standards:
   - FIPS 197: Advanced Encryption Standard (AES)
   - NIST SP 800-38A: Block Cipher Modes of Operation
   
@@ -22,6 +31,7 @@
   - CTR mode for streaming operations
   - NIST test vectors compliance
   - Secure key and IV handling
+  - Raw binary data operations
   
   Security Notes:
   1. This implementation has been tested against NIST test vectors
@@ -33,16 +43,19 @@
     var
       Key: TAESKey;
       IV: TAESBlock;
-      PlainText, CipherText: string;
+      PlainBytes, CipherBytes: TBytes;
     begin
       // Initialize Key and IV (use secure random generation in practice)
       FillChar(Key, SizeOf(Key), 0);
       FillChar(IV, SizeOf(IV), 0);
       
-      // CBC Mode
-      CipherText := TAES256.EncryptCBC(PlainBytes, Key, IV);
-      PlainText := TAES256.DecryptCBC(CipherBytes, Key, IV);
+      // CBC Mode - operates on raw bytes
+      CipherBytes := TAES256.EncryptCBC(PlainBytes, Key, IV);
+      PlainBytes := TAES256.DecryptCBC(CipherBytes, Key, IV);
     end;
+  
+  Note: For string-based operations with automatic Base64 encoding of binary data,
+        use TCryptoKit methods from TidyKit.Crypto unit instead.
   
   @author   TidyKit Team
   @version  1.0

--- a/src/TidyKit.Crypto.AES256.pas
+++ b/src/TidyKit.Crypto.AES256.pas
@@ -721,21 +721,16 @@ begin
   
   // Check and remove PKCS7 padding if present
   PaddingSize := Result[Length(Result) - 1];
-  if (PaddingSize > 0) and (PaddingSize <= 16) then
-  begin
-    // Only verify and remove padding if it's not block-aligned input
-    if PaddingSize < 16 then
-    begin
-      // Verify padding
-      for I := Length(Result) - PaddingSize to Length(Result) - 1 do
-        if Result[I] <> PaddingSize then
-          raise EAESError.Create('Invalid padding');
-      
-      SetLength(Result, Length(Result) - PaddingSize);
-    end;
-  end
-  else
+  if (PaddingSize = 0) or (PaddingSize > 16) then
     raise EAESError.Create('Invalid padding');
+    
+  // Verify all padding bytes match
+  for I := Length(Result) - PaddingSize to Length(Result) - 1 do
+    if Result[I] <> PaddingSize then
+      raise EAESError.Create('Invalid padding');
+      
+  // Remove padding after successful validation
+  SetLength(Result, Length(Result) - PaddingSize);
 end;
 
 {*******************************************************************************

--- a/src/TidyKit.Crypto.AES256.pas
+++ b/src/TidyKit.Crypto.AES256.pas
@@ -27,11 +27,29 @@
   
   Key Features:
   - AES-256 block cipher (14 rounds)
-  - CBC mode with PKCS7 padding
-  - CTR mode for streaming operations
+  - CBC mode with configurable padding:
+    * PKCS7 padding for general use (RFC 5652)
+    * No padding for NIST test vectors and block-aligned data
+  - CTR mode for streaming operations (no padding needed)
   - NIST test vectors compliance
   - Secure key and IV handling
   - Raw binary data operations
+  
+  Padding Modes:
+  1. PKCS7 Padding (Default)
+     - Standard padding scheme defined in RFC 5652
+     - Automatically pads data to block size
+     - Ensures unambiguous unpadding
+     - Required for most standard protocols
+     - Used by default in CBC mode
+  
+  2. No Padding
+     - Input must be a multiple of block size
+     - Used for NIST test vector validation
+     - Suitable for pre-padded or block-aligned data
+     - Required by some protocols that handle padding externally
+  
+  Note: CTR mode never requires padding as it operates as a stream cipher.
   
   Security Notes:
   1. This implementation has been tested against NIST test vectors

--- a/src/TidyKit.Crypto.pas
+++ b/src/TidyKit.Crypto.pas
@@ -460,69 +460,101 @@ end;
 class function TCryptoKit.AES256EncryptCBC(const Data: string; const Key: TAESKey; const IV: TAESBlock): string;
 var
   DataBytes, EncryptedBytes: TBytes;
+  I: Integer;
+  RawStr: string;
 begin
   if Length(Data) = 0 then
     Exit('');
     
+  // Convert string to bytes preserving all values
   SetLength(DataBytes, Length(Data));
-  Move(Data[1], DataBytes[0], Length(Data));
+  for I := 1 to Length(Data) do
+    DataBytes[I-1] := Byte(Data[I]);
     
+  // Encrypt the data
   EncryptedBytes := TAES256.EncryptCBC(DataBytes, Key, IV);
-  SetString(Result, PChar(@EncryptedBytes[0]), Length(EncryptedBytes));
-  Result := EncodeStringBase64(Result);
+  
+  // Convert encrypted bytes to raw string for Base64
+  SetLength(RawStr, Length(EncryptedBytes));
+  for I := 1 to Length(EncryptedBytes) do
+    RawStr[I] := Chr(EncryptedBytes[I-1]);
+  Result := EncodeStringBase64(RawStr);
 end;
 
 class function TCryptoKit.AES256DecryptCBC(const Base64Data: string; const Key: TAESKey; const IV: TAESBlock): string;
 var
   EncryptedData, DecryptedBytes: TBytes;
   DecodedStr: string;
+  I: Integer;
 begin
   if Length(Base64Data) = 0 then
     Exit('');
     
+  // Decode Base64 to raw string first
   DecodedStr := DecodeStringBase64(Base64Data);
-  SetLength(EncryptedData, Length(DecodedStr));
-  Move(DecodedStr[1], EncryptedData[0], Length(DecodedStr));
   
+  // Convert raw string to bytes
+  SetLength(EncryptedData, Length(DecodedStr));
+  for I := 1 to Length(DecodedStr) do
+    EncryptedData[I-1] := Byte(DecodedStr[I]);
+  
+  // Decrypt the data
   DecryptedBytes := TAES256.DecryptCBC(EncryptedData, Key, IV);
   
+  // Convert decrypted bytes back to string
   SetLength(Result, Length(DecryptedBytes));
-  if Length(DecryptedBytes) > 0 then
-    Move(DecryptedBytes[0], Result[1], Length(DecryptedBytes));
+  for I := 1 to Length(DecryptedBytes) do
+    Result[I] := Chr(DecryptedBytes[I-1]);
 end;
 
 class function TCryptoKit.AES256EncryptCTR(const Data: string; const Key: TAESKey; const IV: TAESBlock): string;
 var
   DataBytes, EncryptedBytes: TBytes;
+  I: Integer;
+  RawStr: string;
 begin
   if Length(Data) = 0 then
     Exit('');
     
+  // Convert string to bytes preserving all values
   SetLength(DataBytes, Length(Data));
-  Move(Data[1], DataBytes[0], Length(Data));
+  for I := 0 to Length(Data) - 1 do
+    DataBytes[I] := Byte(Data[I + 1]);
     
+  // Encrypt the data
   EncryptedBytes := TAES256.EncryptCTR(DataBytes, Key, IV);
-  SetString(Result, PChar(@EncryptedBytes[0]), Length(EncryptedBytes));
-  Result := EncodeStringBase64(Result);
+  
+  // Convert bytes to Base64 directly
+  SetLength(RawStr, Length(EncryptedBytes));
+  for I := 0 to Length(EncryptedBytes) - 1 do
+    RawStr[I + 1] := Chr(EncryptedBytes[I]);
+  Result := EncodeStringBase64(RawStr);
 end;
 
 class function TCryptoKit.AES256DecryptCTR(const Base64Data: string; const Key: TAESKey; const IV: TAESBlock): string;
 var
   EncryptedData, DecryptedBytes: TBytes;
   DecodedStr: string;
+  I: Integer;
 begin
   if Length(Base64Data) = 0 then
     Exit('');
     
+  // Decode Base64 to raw string first
   DecodedStr := DecodeStringBase64(Base64Data);
-  SetLength(EncryptedData, Length(DecodedStr));
-  Move(DecodedStr[1], EncryptedData[0], Length(DecodedStr));
   
+  // Convert raw string to bytes
+  SetLength(EncryptedData, Length(DecodedStr));
+  for I := 0 to Length(DecodedStr) - 1 do
+    EncryptedData[I] := Byte(DecodedStr[I + 1]);
+  
+  // Decrypt the data
   DecryptedBytes := TAES256.DecryptCTR(EncryptedData, Key, IV);
   
+  // Convert decrypted bytes back to string
   SetLength(Result, Length(DecryptedBytes));
-  if Length(DecryptedBytes) > 0 then
-    Move(DecryptedBytes[0], Result[1], Length(DecryptedBytes));
+  for I := 0 to Length(DecryptedBytes) - 1 do
+    Result[I + 1] := Chr(DecryptedBytes[I]);
 end;
 
 class procedure TCryptoKit.FillRandomBytes(var Buffer; Count: Integer);

--- a/src/TidyKit.Crypto.pas
+++ b/src/TidyKit.Crypto.pas
@@ -34,6 +34,12 @@ type
     Defines the operation mode for Blowfish encryption/decryption }
   TBlowfishMode = (bmEncrypt, bmDecrypt);
 
+  { TAESKey - 256-bit key for AES encryption }
+  TAESKey = TidyKit.Crypto.AES256.TAESKey;
+
+  { TAESBlock - 128-bit block for AES encryption }
+  TAESBlock = TidyKit.Crypto.AES256.TAESBlock;
+
 type
   { TCryptoKit
     ----------

--- a/src/TidyKit.Crypto.pas
+++ b/src/TidyKit.Crypto.pas
@@ -2,6 +2,27 @@ unit TidyKit.Crypto;
 
 {$mode objfpc}{$H+}{$J-}
 
+{*******************************************************************************
+  TidyKit.Crypto - High-Level Cryptographic Operations Interface
+  
+  This unit provides a high-level wrapper around various cryptographic operations,
+  making them easy to use with string inputs and outputs. It handles:
+  - String to bytes conversion
+  - Base64 encoding of binary cryptographic outputs
+  - Base64 decoding of encrypted data for decryption
+  
+  Base64 encoding is used because encrypted binary data cannot be safely stored
+  in strings (they may contain null bytes or non-printable characters).
+  This ensures encrypted data can be safely stored and transmitted as text.
+  
+  For low-level binary operations and NIST compliance testing, use the underlying
+  implementation units directly (e.g., TidyKit.Crypto.AES256).
+  
+  @author   TidyKit Team
+  @version  1.0
+  @date     2024
+*******************************************************************************}
+
 interface
 
 uses
@@ -147,47 +168,57 @@ type
     class function BlowfishCrypt(const Text, Key: string; Mode: TBlowfishMode): string; static;
 
     { Encrypts data using AES-256 in CBC mode.
+      This is a high-level wrapper that handles string conversion and Base64 encoding.
+      For raw binary operations, use TAES256.EncryptCBC directly.
       
       Parameters:
-        Data - The data to encrypt.
+        Data - The string data to encrypt.
         Key - 256-bit encryption key.
         IV - 128-bit initialization vector.
         
       Returns:
-        Encrypted data in Base64 format. }
+        Base64-encoded encrypted data string. The Base64 encoding ensures the binary
+        encrypted data can be safely stored and transmitted as text. }
     class function AES256EncryptCBC(const Data: string; const Key: TAESKey; const IV: TAESBlock): string; static;
     
     { Decrypts data using AES-256 in CBC mode.
+      This is a high-level wrapper that handles Base64 decoding and string conversion.
+      For raw binary operations, use TAES256.DecryptCBC directly.
       
       Parameters:
-        Base64Data - The Base64-encoded encrypted data.
+        Base64Data - The Base64-encoded encrypted data string.
         Key - 256-bit encryption key.
         IV - 128-bit initialization vector.
         
       Returns:
-        Decrypted data. }
+        Decrypted string data. }
     class function AES256DecryptCBC(const Base64Data: string; const Key: TAESKey; const IV: TAESBlock): string; static;
     
     { Encrypts data using AES-256 in CTR mode.
+      This is a high-level wrapper that handles string conversion and Base64 encoding.
+      For raw binary operations, use TAES256.EncryptCTR directly.
       
       Parameters:
-        Data - The data to encrypt.
+        Data - The string data to encrypt.
         Key - 256-bit encryption key.
         IV - 128-bit initialization vector (nonce + counter).
         
       Returns:
-        Encrypted data in Base64 format. }
+        Base64-encoded encrypted data string. The Base64 encoding ensures the binary
+        encrypted data can be safely stored and transmitted as text. }
     class function AES256EncryptCTR(const Data: string; const Key: TAESKey; const IV: TAESBlock): string; static;
     
     { Decrypts data using AES-256 in CTR mode.
+      This is a high-level wrapper that handles Base64 decoding and string conversion.
+      For raw binary operations, use TAES256.DecryptCTR directly.
       
       Parameters:
-        Base64Data - The Base64-encoded encrypted data.
+        Base64Data - The Base64-encoded encrypted data string.
         Key - 256-bit encryption key.
         IV - 128-bit initialization vector (nonce + counter).
         
       Returns:
-        Decrypted data. }
+        Decrypted string data. }
     class function AES256DecryptCTR(const Base64Data: string; const Key: TAESKey; const IV: TAESBlock): string; static;
   end;
 

--- a/src/TidyKit.Crypto.pas
+++ b/src/TidyKit.Crypto.pas
@@ -18,6 +18,21 @@ unit TidyKit.Crypto;
   For low-level binary operations and NIST compliance testing, use the underlying
   implementation units directly (e.g., TidyKit.Crypto.AES256).
   
+  AES-256 Implementation:
+  1. High-Level Interface (this unit)
+     - String-based operations with automatic Base64 encoding
+     - Always uses PKCS7 padding in CBC mode for safety
+     - CTR mode for streaming (no padding needed)
+     - Suitable for most applications
+  
+  2. Low-Level Interface (TidyKit.Crypto.AES256)
+     - Raw binary operations
+     - Configurable padding modes:
+       * PKCS7 for general use
+       * No padding for NIST testing
+     - Direct byte array manipulation
+     - Used for testing and special protocols
+  
   @author   TidyKit Team
   @version  1.0
   @date     2024

--- a/src/TidyKit.Crypto.pas
+++ b/src/TidyKit.Crypto.pas
@@ -24,6 +24,7 @@ unit TidyKit.Crypto;
      - Always uses PKCS7 padding in CBC mode for safety
      - CTR mode for streaming (no padding needed)
      - Suitable for most applications
+     - No padding mode configuration (uses safe defaults)
   
   2. Low-Level Interface (TidyKit.Crypto.AES256)
      - Raw binary operations
@@ -32,6 +33,24 @@ unit TidyKit.Crypto;
        * No padding for NIST testing
      - Direct byte array manipulation
      - Used for testing and special protocols
+     - Full control over padding modes
+  
+  Design Choices:
+  1. Padding Modes
+     - High-level interface enforces safe defaults:
+       * CBC mode always uses PKCS7 padding
+       * CTR mode never needs padding
+       * No padding configuration exposed
+     - Low-level interface provides full control:
+       * Configurable padding for special cases
+       * Required for NIST test vectors
+       * Used by crypto implementers
+  
+  2. Security
+     - Prevents padding oracle vulnerabilities
+     - Enforces cryptographic best practices
+     - Minimizes API surface for safety
+     - Hides complexity from regular users
   
   @author   TidyKit Team
   @version  1.0

--- a/src/TidyKit.Crypto.pas
+++ b/src/TidyKit.Crypto.pas
@@ -383,7 +383,8 @@ begin
     Move(Data[1], DataBytes[0], Length(Data));
     
   EncryptedBytes := TAES256.EncryptCBC(DataBytes, Key, IV);
-  Result := Base64Encode(PChar(@EncryptedBytes[0]), Length(EncryptedBytes));
+  SetString(Result, PChar(@EncryptedBytes[0]), Length(EncryptedBytes));
+  Result := EncodeStringBase64(Result);
 end;
 
 class function TCryptoKit.AES256DecryptCBC(const Base64Data: string; const Key: TAESKey; const IV: TAESBlock): string;
@@ -415,7 +416,8 @@ begin
     Move(Data[1], DataBytes[0], Length(Data));
     
   EncryptedBytes := TAES256.EncryptCTR(DataBytes, Key, IV);
-  Result := Base64Encode(PChar(@EncryptedBytes[0]), Length(EncryptedBytes));
+  SetString(Result, PChar(@EncryptedBytes[0]), Length(EncryptedBytes));
+  Result := EncodeStringBase64(Result);
 end;
 
 class function TCryptoKit.AES256DecryptCTR(const Base64Data: string; const Key: TAESKey; const IV: TAESBlock): string;

--- a/src/TidyKit.Crypto.pas
+++ b/src/TidyKit.Crypto.pas
@@ -564,6 +564,7 @@ end;
 
 class function TCryptoKit.DeriveKey(const Password: string; const Salt: string;
   Iterations: Integer): TAESKey;
+{$R-} // Disable range checking for array operations
 var
   I, J: Integer;
   Counter: Cardinal;
@@ -626,5 +627,6 @@ begin
   for I := 0 to 31 do
     Result[I] := Result[I] xor TempKey[I];
 end;
+{$R+} // Re-enable range checking
 
 end. 

--- a/src/TidyKit.pas
+++ b/src/TidyKit.pas
@@ -11,6 +11,7 @@ uses
   TidyKit.Strings,
   TidyKit.DateTime,
   TidyKit.Crypto,
+  TidyKit.Crypto.AES256,
   TidyKit.Request,
   TidyKit.Math,
   TidyKit.Math.Matrices,
@@ -36,6 +37,8 @@ type
   { Re-export the crypto types }
   TCryptoKit = TidyKit.Crypto.TCryptoKit;
   TBlowfishMode = TidyKit.Crypto.TBlowfishMode;
+  TAESKey = TidyKit.Crypto.TAESKey;
+  TAESBlock = TidyKit.Crypto.TAESBlock;
 
   { Re-export the request types }
   TResponse = TidyKit.Request.TResponse;

--- a/tests/TestCaseCrypto.pas
+++ b/tests/TestCaseCrypto.pas
@@ -1155,15 +1155,19 @@ end;
 procedure TTestCaseCrypto.Test109_AES256CBCInvalidKey;
 var
   InvalidKey: TAESKey;
-  Encrypted, Decrypted: string;
+  Encrypted: string;
 begin
   Encrypted := TCryptoKit.AES256EncryptCBC(FPlainText, FAESKey, FAESIV);
   
   // Try decrypting with a different key
   FillChar(InvalidKey, SizeOf(InvalidKey), 0);
-  Decrypted := TCryptoKit.AES256DecryptCBC(Encrypted, InvalidKey, FAESIV);
-  AssertTrue('Decryption with wrong key should not match original', 
-             FPlainText <> Decrypted);
+  try
+    TCryptoKit.AES256DecryptCBC(Encrypted, InvalidKey, FAESIV);
+    Fail('Should raise EAESError when using invalid key');
+  except
+    on E: EAESError do
+      ; // Expected - decryption with wrong key should fail
+  end;
 end;
 
 // AES-256 CTR Tests

--- a/tests/TestRunner.lpr
+++ b/tests/TestRunner.lpr
@@ -5,13 +5,13 @@ program TestRunner;
 uses
   Classes
   , consoletestrunner
-  , TestCaseDateTime
-  , TestCaseFS
-  , TestCaseString
+  //, TestCaseDateTime
+  //, TestCaseFS
+  //, TestCaseString
   , TestCaseCrypto
-  , TestCaseRequest
-  , TestCaseMath
-  , TestCaseArchive
+  //, TestCaseRequest
+  //, TestCaseMath
+  //, TestCaseArchive
   , TidyKit.Crypto.AES256.Test;
 
 type

--- a/tests/TestRunner.lpr
+++ b/tests/TestRunner.lpr
@@ -5,13 +5,13 @@ program TestRunner;
 uses
   Classes
   , consoletestrunner
-  //, TestCaseDateTime
-  //, TestCaseFS
-  //, TestCaseString
-  //, TestCaseCrypto
-  //, TestCaseRequest
-  //, TestCaseMath
-  //, TestCaseArchive;
+  , TestCaseDateTime
+  , TestCaseFS
+  , TestCaseString
+  , TestCaseCrypto
+  , TestCaseRequest
+  , TestCaseMath
+  , TestCaseArchive
   , TidyKit.Crypto.AES256.Test;
 
 type

--- a/tests/TestRunner.lpr
+++ b/tests/TestRunner.lpr
@@ -5,13 +5,13 @@ program TestRunner;
 uses
   Classes
   , consoletestrunner
-  //, TestCaseDateTime
-  //, TestCaseFS
-  //, TestCaseString
+  , TestCaseDateTime
+  , TestCaseFS
+  , TestCaseString
   , TestCaseCrypto
-  //, TestCaseRequest
-  //, TestCaseMath
-  //, TestCaseArchive
+  , TestCaseRequest
+  , TestCaseMath
+  , TestCaseArchive
   , TidyKit.Crypto.AES256.Test;
 
 type

--- a/tests/TidyKit.Crypto.AES256.Test.pas
+++ b/tests/TidyKit.Crypto.AES256.Test.pas
@@ -85,7 +85,7 @@ begin
   IVBytes := HexToBytes(IV);
   PlainBytes := HexToBytes(Plaintext);
   
-  CipherBytes := TAES256.EncryptCBC(PlainBytes, BytesToKey(KeyBytes), BytesToBlock(IVBytes));
+  CipherBytes := TAES256.EncryptCBC(PlainBytes, BytesToKey(KeyBytes), BytesToBlock(IVBytes), apNone);
   AssertEquals('CBC encryption failed', ExpectedCiphertext.ToLower, 
                BytesToHex(CipherBytes).ToLower);
 end;
@@ -110,7 +110,7 @@ begin
   IVBytes := HexToBytes(IV);
   CipherBytes := HexToBytes(Ciphertext);
   
-  PlainBytes := TAES256.DecryptCBC(CipherBytes, BytesToKey(KeyBytes), BytesToBlock(IVBytes));
+  PlainBytes := TAES256.DecryptCBC(CipherBytes, BytesToKey(KeyBytes), BytesToBlock(IVBytes), apNone);
   AssertEquals('CBC decryption failed', ExpectedPlaintext.ToLower, 
                BytesToHex(PlainBytes).ToLower);
 end;


### PR DESCRIPTION
# Description

Hotfix - High level wrapper for AES256 was broken. Added helper functions for generating keys and IVs.
Feature - added padding modes for two scenarios; checking against NIST test vectors and normal use.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Testing

Updated TestCaseCrypto.pas, compiled and ran the following.

```pascal
./TestRunner.exe -a --format=plain
``` 