### PR TITLE
Feature: Re-export JSON types in TidyKit main unit

### DIFF
--- a/src/TidyKit.pas
+++ b/src/TidyKit.pas
@@ -12,6 +12,7 @@ uses
   TidyKit.DateTime,
   TidyKit.Crypto,
   TidyKit.Crypto.AES256,
+  TidyKit.JSON,
   TidyKit.Request,
   TidyKit.Math,
   TidyKit.Math.Matrices,
@@ -33,6 +34,13 @@ type
   TSearchResult = TidyKit.FS.TSearchResult;
   TFilePathArray = TidyKit.FS.TFilePathArray;
   TDirectoryInfo = TidyKit.FS.TDirectoryInfo;
+
+  { Re-export the JSON types }
+  TJSON = TidyKit.JSON.TJSON;
+  IJSONValue = TidyKit.JSON.IJSONValue;
+  IJSONObject = TidyKit.JSON.IJSONObject;
+  IJSONArray = TidyKit.JSON.IJSONArray;
+  EJSONException = TidyKit.JSON.EJSONException;
 
   { Re-export the crypto types }
   TCryptoKit = TidyKit.Crypto.TCryptoKit;

--- a/tests/TidyKit.JSON.Test.pas
+++ b/tests/TidyKit.JSON.Test.pas
@@ -6,7 +6,9 @@ interface
 
 uses
   Classes, SysUtils, fpcunit, testregistry,
-  TidyKit.JSON, TidyKit.JSON.Types, TidyKit.JSON.Factory, Math;
+  TidyKit,
+  // Alternatively, TidyKit.JSON,
+  Math;
 
 type
   TJSONTest = class(TTestCase)


### PR DESCRIPTION
# Description

Feature: Re-export JSON types in TidyKit main unit

- Add JSON-related type re-exports to TidyKit.pas
- Update test file to use simplified TidyKit import
- Improve module integration and ease of use for JSON functionality

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [-] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Testing

Nothing changed.
All test passed using the following command.

```pascal
./TestRunner.exe -a --format=plain
``` 